### PR TITLE
Raising Environment Error on Single Node Clusters

### DIFF
--- a/dask_databricks/databrickscluster.py
+++ b/dask_databricks/databrickscluster.py
@@ -29,6 +29,13 @@ class DatabricksCluster(Cluster):
                 "Unable to find expected environment variable SPARK_LOCAL_IP. "
                 "Are you running this on a Databricks driver node?"
             )
+        if os.getenv("MASTER") and "local[" in os.getenv("MASTER"):
+            raise EnvironmentError(
+                "You appear to be running dask-databricks on a "
+                "single-node cluster. Dask requires at least one worker node "
+                "in order to function as expected."
+
+            )
         try:
             name = spark.conf.get("spark.databricks.clusterUsageTags.clusterId")
         except AttributeError:

--- a/dask_databricks/databrickscluster.py
+++ b/dask_databricks/databrickscluster.py
@@ -23,13 +23,13 @@ class DatabricksCluster(Cluster):
         loop: Optional[IOLoop] = None,
         asynchronous: bool = False,
     ):
-        self.spark_local_ip = os.getenv("SPARK_LOCAL_IP")
+        self.spark_local_ip = os.environ.get("SPARK_LOCAL_IP")
         if self.spark_local_ip is None:
             raise KeyError(
                 "Unable to find expected environment variable SPARK_LOCAL_IP. "
                 "Are you running this on a Databricks driver node?"
             )
-        if os.getenv("MASTER") and "local[" in os.getenv("MASTER"):
+        if os.environ.get("MASTER") and "local[" in os.environ.get("MASTER"):
             raise EnvironmentError(
                 "You appear to be running dask-databricks on a "
                 "single-node cluster. Dask requires at least one worker node "

--- a/dask_databricks/databrickscluster.py
+++ b/dask_databricks/databrickscluster.py
@@ -31,9 +31,9 @@ class DatabricksCluster(Cluster):
             )
         if os.environ.get("MASTER") and "local[" in os.environ.get("MASTER"):
             raise EnvironmentError(
-                "You appear to be running dask-databricks on a "
-                "single-node cluster. Dask requires at least one worker node "
-                "in order to function as expected."
+                "You appear to be trying to run a multi-node Dask cluster on a "
+                "single-node databricks cluster. Maybe you want "
+                "`dask.distributed.LocalCluster().get_client()` instead"
 
             )
         try:

--- a/dask_databricks/tests/test_databricks.py
+++ b/dask_databricks/tests/test_databricks.py
@@ -38,6 +38,14 @@ def test_databricks_cluster_raises_key_error_when_initialised_outside_of_databri
     with pytest.raises(KeyError):
         DatabricksCluster()
 
+def test_databricks_cluster_raises_environment_error_when_master_variable_implies_single_node(
+    monkeypatch,
+    set_spark_local_ip,
+    dask_cluster,
+):
+    monkeypatch.setenv("MASTER", "local[8]")
+    with pytest.raises(EnvironmentError):
+        DatabricksCluster()
 
 def test_databricks_cluster_create(set_spark_local_ip, dask_cluster):
     cluster = DatabricksCluster()


### PR DESCRIPTION
This addresses #39 - would appreciate some feedback as I'm not sure if this is a great idea or not.

Currently, if you start `client = dask_databricks.client()` on a single node databricks cluster, it'll allow you to, but then hang indefinitely if you try to carry out any tasks (makes sense since there are no workers to do them).

My thinking is it would be handy to throw an error if we can since if we're on a single-node cluster we already know that any attempted use of the dask_databricks client is going to end badly.

I wanted to implement this a little like this: 
```python
if os.getenv("NUMNODES") == "1":
    raise EnvironmentError(
        "You appear to be running dask-databricks on a "
        "single-node cluster. Dask requires at least one worker node "
        "in order to function as expected."
    )
```
But databricks doesn't appear to have an environment variable like "NUMNODES" - it does have a "MASTER" environment variable, which for single node clusters tells you the core working as the driver (such as `local[4]`) and in distributed clusters gives you the tcp url.

I've used that to implement it like this:

```python
if os.getenv("MASTER") and "local[" in os.getenv("MASTER"):
```

My thinking is that this is a pretty conservative check (owing to the fact that databricks could hypothetically change this implementation detail at some point, and I can't find any documentation of it). If there is no `MASTER` variable, nothing will get raised, so the only possible false positive is if `local[4]` is set as `MASTER` in a multi-node cluster which I don't think is possible?

It's still a little hackier than I'd of liked though, but does boost the user-friendliness for beginners. Any thoughts?